### PR TITLE
Fix CLI runner

### DIFF
--- a/bin/ts-oas
+++ b/bin/ts-oas
@@ -1,3 +1,2 @@
 #!/usr/bin/env node
-var app = require('../dist/cli.js');
-app.run();
+require('../dist/cli.js');


### PR DESCRIPTION
### Current Behavior
Executing ts-oas from CLI throws the following error:
```
C:\Users\xxxx\github\someproject\node_modules\ts-oas\bin\ts-oas:3
app.run();
    ^

TypeError: app.run is not a function
    at Object.<anonymous> (C:\Users\xxxx\github\someproject\node_modules\ts-oas\bin\ts-oas:3:5)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
```
The error occurs whether running with module installed local to a project, globally, or using npx.

The tool does complete the work before throwing this error.

This error was reproduced on MacOS and Windows 10.

### Expected Behavior
No error is thrown.

### Solution
We can remove the line of code that calls "run()" on the cli.js module required. That module doesn't export anything, it just executes everything when required.