### PR TITLE
Add support for No Content Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ export type GetBarAPI = ApiMapper<{
          * @contentType application/json
          */
         "200": Bar;
+        /** 
+         * No Content 
+         */
+        "204": never;
         "404": { success: false };
     };
 }>;

--- a/src/lib/TypescriptOAS.ts
+++ b/src/lib/TypescriptOAS.ts
@@ -166,11 +166,13 @@ export class TypescriptOAS extends SchemaGenerator {
                 responses[respSymbol.escapedName as string]["description"] = "";
             }
 
-            responses[respSymbol.escapedName as string].content = {
-                [contentType]: {
-                    schema: this.getTypeDefinition(respType, this.args.ref, undefined, undefined, respType.aliasSymbol),
-                },
-            };
+            if (this.getTypeFromSymbol(respSymbol).flags !== ts.TypeFlags.Never) {
+                responses[respSymbol.escapedName as string].content = {
+                    [contentType]: {
+                        schema: this.getTypeDefinition(respType, this.args.ref, undefined, undefined, respType.aliasSymbol),
+                    },
+                };
+            }
         }
 
         return responses;
@@ -196,8 +198,8 @@ export class TypescriptOAS extends SchemaGenerator {
                     [property]:
                         propertyItems instanceof Array && propertyItems?.length
                             ? propertyItems
-                                .filter((item) => item.type === "string" && item.enum)
-                                .map((item) => item.enum![0])
+                                  .filter((item) => item.type === "string" && item.enum)
+                                  .map((item) => item.enum![0])
                             : [],
                 });
             }

--- a/src/lib/TypescriptOAS.ts
+++ b/src/lib/TypescriptOAS.ts
@@ -166,7 +166,7 @@ export class TypescriptOAS extends SchemaGenerator {
                 responses[respSymbol.escapedName as string]["description"] = "";
             }
 
-            if (this.getTypeFromSymbol(respSymbol).flags !== ts.TypeFlags.Never) {
+            if (respType.flags !== ts.TypeFlags.Never) {
                 responses[respSymbol.escapedName as string].content = {
                     [contentType]: {
                         schema: this.getTypeDefinition(respType, this.args.ref, undefined, undefined, respType.aliasSymbol),
@@ -222,11 +222,11 @@ export class TypescriptOAS extends SchemaGenerator {
         this.resetSchemaSpecificProperties();
         this.refPath = "#/components/schemas/";
 
-        if (!specData.info) specData.info = { title: "OpenAPI specification", version: "1.0.0" };
-
         const spec: OpenApiSpec = {
             openapi: "3.0.3",
+            info: specData.info || { title: "OpenAPI specification", version: "1.0.0" },
             ...specData,
+            components: specData.components,
             paths: {},
         };
 
@@ -296,6 +296,8 @@ export class TypescriptOAS extends SchemaGenerator {
                 ...this.reffedDefinitions,
                 ...spec.components.schemas,
             };
+        } else if (spec.components === undefined){
+            delete spec.components;
         }
 
         return spec;

--- a/test/openapi/openapi-with-ref.schema.json
+++ b/test/openapi/openapi-with-ref.schema.json
@@ -1,78 +1,6 @@
 {
   "openapi": "3.0.3",
   "info": { "title": "OpenAPI specification", "version": "1.0.0" },
-  "components": {
-    "schemas": {
-      "GetAllBooksQuery": {
-        "type": "object",
-        "properties": {
-          "query-status": {
-            "x-thisIsCustom": "value",
-            "type": "array",
-            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
-          }
-        }
-      },
-      "Book": {
-        "type": "object",
-        "properties": {
-          "id": { "description": "this is id.", "type": "number" },
-          "title": {
-            "default": "sample title",
-            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
-          },
-          "date": {
-            "format": "date",
-            "anyOf": [
-              { "type": "object", "nullable": true },
-              { "type": "string", "format": "date-time" }
-            ]
-          },
-          "meta-data": { "type": "object" },
-          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
-        },
-        "required": ["id", "meta-data", "statuses", "title"]
-      },
-      "GetAllBooksQueryRes": { "type": "array", "items": { "$ref": "#/components/schemas/Book" } },
-      "ResponseUnsuccessData": {
-        "type": "object",
-        "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
-        "required": ["msg"]
-      },
-      "EditBookQuery": {
-        "type": "object",
-        "properties": {
-          "another_field": { "type": "string" },
-          "query-status": {
-            "x-thisIsCustom": "value",
-            "type": "array",
-            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
-          }
-        },
-        "required": ["another_field"]
-      },
-      "EditBookRes": {
-        "type": "object",
-        "properties": {
-          "id": { "description": "this is id.", "type": "number" },
-          "title": {
-            "default": "sample title",
-            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
-          },
-          "date": {
-            "format": "date",
-            "anyOf": [
-              { "type": "object", "nullable": true },
-              { "type": "string", "format": "date-time" }
-            ]
-          },
-          "meta-data": { "type": "object" },
-          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
-        },
-        "required": ["id", "meta-data", "statuses", "title"]
-      }
-    }
-  },
   "paths": {
     "/category/book": {
       "get": {
@@ -173,8 +101,81 @@
                 }
               }
             }
+          },
+          "204": { "description": "No Content" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetAllBooksQuery": {
+        "type": "object",
+        "properties": {
+          "query-status": {
+            "x-thisIsCustom": "value",
+            "type": "array",
+            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
           }
         }
+      },
+      "GetAllBooksQueryRes": { "type": "array", "items": { "$ref": "#/components/schemas/Book" } },
+      "Book": {
+        "type": "object",
+        "properties": {
+          "id": { "description": "this is id.", "type": "number" },
+          "title": {
+            "default": "sample title",
+            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+          },
+          "date": {
+            "format": "date",
+            "anyOf": [
+              { "type": "object", "nullable": true },
+              { "type": "string", "format": "date-time" }
+            ]
+          },
+          "meta-data": { "type": "object" },
+          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
+        },
+        "required": ["id", "meta-data", "statuses", "title"]
+      },
+      "ResponseUnsuccessData": {
+        "type": "object",
+        "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
+        "required": ["msg"]
+      },
+      "EditBookQuery": {
+        "type": "object",
+        "properties": {
+          "another_field": { "type": "string" },
+          "query-status": {
+            "x-thisIsCustom": "value",
+            "type": "array",
+            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+          }
+        },
+        "required": ["another_field"]
+      },
+      "EditBookRes": {
+        "type": "object",
+        "properties": {
+          "id": { "description": "this is id.", "type": "number" },
+          "title": {
+            "default": "sample title",
+            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+          },
+          "date": {
+            "format": "date",
+            "anyOf": [
+              { "type": "object", "nullable": true },
+              { "type": "string", "format": "date-time" }
+            ]
+          },
+          "meta-data": { "type": "object" },
+          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
+        },
+        "required": ["id", "meta-data", "statuses", "title"]
       }
     }
   }

--- a/test/openapi/openapi-with-ref.schema.json
+++ b/test/openapi/openapi-with-ref.schema.json
@@ -1,6 +1,78 @@
 {
   "openapi": "3.0.3",
   "info": { "title": "OpenAPI specification", "version": "1.0.0" },
+  "components": {
+    "schemas": {
+      "GetAllBooksQuery": {
+        "type": "object",
+        "properties": {
+          "query-status": {
+            "x-thisIsCustom": "value",
+            "type": "array",
+            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+          }
+        }
+      },
+      "Book": {
+        "type": "object",
+        "properties": {
+          "id": { "description": "this is id.", "type": "number" },
+          "title": {
+            "default": "sample title",
+            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+          },
+          "date": {
+            "format": "date",
+            "anyOf": [
+              { "type": "object", "nullable": true },
+              { "type": "string", "format": "date-time" }
+            ]
+          },
+          "meta-data": { "type": "object" },
+          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
+        },
+        "required": ["id", "meta-data", "statuses", "title"]
+      },
+      "GetAllBooksQueryRes": { "type": "array", "items": { "$ref": "#/components/schemas/Book" } },
+      "ResponseUnsuccessData": {
+        "type": "object",
+        "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
+        "required": ["msg"]
+      },
+      "EditBookQuery": {
+        "type": "object",
+        "properties": {
+          "another_field": { "type": "string" },
+          "query-status": {
+            "x-thisIsCustom": "value",
+            "type": "array",
+            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+          }
+        },
+        "required": ["another_field"]
+      },
+      "EditBookRes": {
+        "type": "object",
+        "properties": {
+          "id": { "description": "this is id.", "type": "number" },
+          "title": {
+            "default": "sample title",
+            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+          },
+          "date": {
+            "format": "date",
+            "anyOf": [
+              { "type": "object", "nullable": true },
+              { "type": "string", "format": "date-time" }
+            ]
+          },
+          "meta-data": { "type": "object" },
+          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
+        },
+        "required": ["id", "meta-data", "statuses", "title"]
+      }
+    }
+  },
   "paths": {
     "/category/book": {
       "get": {
@@ -104,78 +176,6 @@
           },
           "204": { "description": "No Content" }
         }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GetAllBooksQuery": {
-        "type": "object",
-        "properties": {
-          "query-status": {
-            "x-thisIsCustom": "value",
-            "type": "array",
-            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
-          }
-        }
-      },
-      "GetAllBooksQueryRes": { "type": "array", "items": { "$ref": "#/components/schemas/Book" } },
-      "Book": {
-        "type": "object",
-        "properties": {
-          "id": { "description": "this is id.", "type": "number" },
-          "title": {
-            "default": "sample title",
-            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
-          },
-          "date": {
-            "format": "date",
-            "anyOf": [
-              { "type": "object", "nullable": true },
-              { "type": "string", "format": "date-time" }
-            ]
-          },
-          "meta-data": { "type": "object" },
-          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
-        },
-        "required": ["id", "meta-data", "statuses", "title"]
-      },
-      "ResponseUnsuccessData": {
-        "type": "object",
-        "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
-        "required": ["msg"]
-      },
-      "EditBookQuery": {
-        "type": "object",
-        "properties": {
-          "another_field": { "type": "string" },
-          "query-status": {
-            "x-thisIsCustom": "value",
-            "type": "array",
-            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
-          }
-        },
-        "required": ["another_field"]
-      },
-      "EditBookRes": {
-        "type": "object",
-        "properties": {
-          "id": { "description": "this is id.", "type": "number" },
-          "title": {
-            "default": "sample title",
-            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
-          },
-          "date": {
-            "format": "date",
-            "anyOf": [
-              { "type": "object", "nullable": true },
-              { "type": "string", "format": "date-time" }
-            ]
-          },
-          "meta-data": { "type": "object" },
-          "statuses": { "type": "array", "items": { "enum": ["four", "one", "three", "two"], "type": "string" } }
-        },
-        "required": ["id", "meta-data", "statuses", "title"]
       }
     }
   }

--- a/test/openapi/openapi-with-security.schema.json
+++ b/test/openapi/openapi-with-security.schema.json
@@ -1,6 +1,5 @@
 {
   "openapi": "3.0.3",
-  "info": { "title": "OpenAPI specification", "version": "1.0.0" },
   "components": {
     "securitySchemes": {
       "bearerToken": {
@@ -12,6 +11,7 @@
       "basicAuth": { "type": "http", "scheme": "basic" }
     }
   },
+  "info": { "title": "OpenAPI specification", "version": "1.0.0" },
   "paths": {
     "/category/book": {
       "get": {
@@ -167,7 +167,8 @@
                 }
               }
             }
-          }
+          },
+          "204": { "description": "No Content" }
         },
         "security": [{ "basicAuth": [] }, { "bearerToken": ["book:write", "book:read"] }]
       }

--- a/test/openapi/openapi-with-security.schema.json
+++ b/test/openapi/openapi-with-security.schema.json
@@ -1,5 +1,6 @@
 {
   "openapi": "3.0.3",
+  "info": { "title": "OpenAPI specification", "version": "1.0.0" },
   "components": {
     "securitySchemes": {
       "bearerToken": {
@@ -11,7 +12,6 @@
       "basicAuth": { "type": "http", "scheme": "basic" }
     }
   },
-  "info": { "title": "OpenAPI specification", "version": "1.0.0" },
   "paths": {
     "/category/book": {
       "get": {

--- a/test/openapi/openapi.schema.json
+++ b/test/openapi/openapi.schema.json
@@ -156,7 +156,8 @@
                 }
               }
             }
-          }
+          },
+          "204": { "description": "No Content" }
         }
       }
     }

--- a/test/openapi/openapi.ts
+++ b/test/openapi/openapi.ts
@@ -49,7 +49,7 @@ type GetAllBooksApi = ApiMapper<{
 interface EditBookQuery extends GetAllBooksQuery {
     another_field: string;
 }
-interface EditBookRes extends Book { }
+interface EditBookRes extends Book {}
 
 type EditBookApi = {
     path: "/category/book/:id";
@@ -57,7 +57,13 @@ type EditBookApi = {
     param: { id: number };
     query: EditBookQuery;
     body: {};
-    responses: { "200": Response<EditBookRes> };
+    responses: {
+        "200": Response<EditBookRes>;
+        /**
+         * No Content
+         */
+        "204": never;
+    };
 };
 
 type EditBookSecureApi = {
@@ -66,7 +72,13 @@ type EditBookSecureApi = {
     param: { id: number };
     query: EditBookQuery;
     body: {};
-    responses: { "200": Response<EditBookRes> };
+    responses: {
+        "200": Response<EditBookRes>;
+        /**
+         * No Content
+         */
+        "204": never;
+    };
     security: [{ basicAuth: [] }, { bearerToken: ["book:write", "book:read"] }];
 };
 


### PR DESCRIPTION
## Add Support for No Content Responses

Whenever the response has a `type` for `never`, no content construct will be added to OAS

```
export type GetBarAPI = ApiMapper<{
    path: "/foo/bar/:id";
    method: "GET";
    params: {
        id: number;
    };
    query: {
        from_date: Date;
    };
    responses: {
        /**
         * @contentType application/json
         */
        "200": Bar;
        /** 
         * No Content 
         */
        "204": never;
        "404": { success: false };
    };
}>;
```