### PR TITLE
fix: empty override for empty security api

### DIFF
--- a/src/lib/TypescriptOAS.ts
+++ b/src/lib/TypescriptOAS.ts
@@ -186,9 +186,7 @@ export class TypescriptOAS extends SchemaGenerator {
         const security: OpenAPIV3.SecurityRequirementObject[] = [];
         const typeDef = this.getTypeDefinition(type);
 
-        if (!typeDef?.items) {
-            return undefined;
-        }
+        if (typeDef?.items === undefined) { return []; }
 
         for (const itemIndex in typeDef.items) {
             const obj = typeDef.items[itemIndex] as Definition;
@@ -198,8 +196,8 @@ export class TypescriptOAS extends SchemaGenerator {
                     [property]:
                         propertyItems instanceof Array && propertyItems?.length
                             ? propertyItems
-                                  .filter((item) => item.type === "string" && item.enum)
-                                  .map((item) => item.enum![0])
+                                .filter((item) => item.type === "string" && item.enum)
+                                .map((item) => item.enum![0])
                             : [],
                 });
             }
@@ -281,7 +279,7 @@ export class TypescriptOAS extends SchemaGenerator {
             // security
             if (securitySymbol) {
                 operation.security = this.getSecurity(this.getTypeFromSymbol(securitySymbol));
-                if (!operation.security) delete operation.security;
+                if (operation.security === undefined) delete operation.security;
             }
 
             const currPath = this.getPath(this.getTypeFromSymbol(pathSymbol));
@@ -296,7 +294,7 @@ export class TypescriptOAS extends SchemaGenerator {
                 ...this.reffedDefinitions,
                 ...spec.components.schemas,
             };
-        } else if (spec.components === undefined){
+        } else if (spec.components === undefined) {
             delete spec.components;
         }
 

--- a/test/openapi/openapi-with-default-security.schema.json
+++ b/test/openapi/openapi-with-default-security.schema.json
@@ -1,0 +1,174 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "OpenAPI specification", "version": "1.0.0" },
+  "security": [{ "basicAuth": [] }, { "bearerToken": ["book:write", "book:read"] }],
+  "components": {
+    "securitySchemes": {
+      "bearerToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Bearer Token with JWT"
+      },
+      "basicAuth": { "type": "http", "scheme": "basic" }
+    }
+  },
+  "paths": {
+    "/category/book": {
+      "get": {
+        "operationId": "GetAllUnsecureBooksApi",
+        "parameters": [
+          {
+            "name": "query-status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "x-thisIsCustom": "value",
+              "type": "array",
+              "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "description": "this is id.", "type": "number" },
+                          "title": {
+                            "default": "sample title",
+                            "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+                          },
+                          "date": {
+                            "format": "date",
+                            "anyOf": [
+                              { "type": "object", "nullable": true },
+                              { "type": "string", "format": "date-time" }
+                            ]
+                          },
+                          "meta-data": { "type": "object" },
+                          "statuses": {
+                            "type": "array",
+                            "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+                          }
+                        },
+                        "required": ["id", "meta-data", "statuses", "title"]
+                      }
+                    }
+                  },
+                  "required": ["data", "success"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
+                      "required": ["msg"]
+                    }
+                  },
+                  "required": ["data", "success"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Oh! Internal Error!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": { "msg": { "type": "string", "enum": ["This is unsuccess."] } },
+                      "required": ["msg"]
+                    }
+                  },
+                  "required": ["data", "success"]
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/category/book/:id": {
+      "patch": {
+        "operationId": "EditBookApi",
+        "parameters": [
+          { "name": "another_field", "in": "query", "required": true, "schema": { "type": "string" } },
+          {
+            "name": "query-status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "x-thisIsCustom": "value",
+              "type": "array",
+              "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "description": "this is id.", "type": "number" },
+                        "title": {
+                          "default": "sample title",
+                          "anyOf": [{ "type": "object", "nullable": true }, { "type": "string" }]
+                        },
+                        "date": {
+                          "format": "date",
+                          "anyOf": [
+                            { "type": "object", "nullable": true },
+                            { "type": "string", "format": "date-time" }
+                          ]
+                        },
+                        "meta-data": { "type": "object" },
+                        "statuses": {
+                          "type": "array",
+                          "items": { "enum": ["four", "one", "three", "two"], "type": "string" }
+                        }
+                      },
+                      "required": ["id", "meta-data", "statuses", "title"]
+                    }
+                  },
+                  "required": ["data", "success"]
+                }
+              }
+            }
+          },
+          "204": { "description": "No Content" }
+        }
+      }
+    }
+  }
+}

--- a/test/openapi/openapi.ts
+++ b/test/openapi/openapi.ts
@@ -45,6 +45,7 @@ type GetAllBooksApi = ApiMapper<{
     query: GetAllBooksQuery;
     responses: { "200": Response<GetAllBooksQueryRes> } & DefaultResp;
 }>;
+type GetAllUnsecureBooksApi = GetAllBooksApi & {security: []};
 
 interface EditBookQuery extends GetAllBooksQuery {
     another_field: string;


### PR DESCRIPTION
This change validates if the security typedef is not undefined, and if not, returns an empty array for security parameter.

Returning undefined turns out to not adding the security construct, rendering impossible to *un-secure* a api with default security construct.