### PR TITLE
allow use of `anyOf` or `oneOf` for union types

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -6,6 +6,8 @@ export type AnnotationKeywords = {
     [prop: string]: boolean | "custom";
 };
 
+export type UnionModifier = 'anyOf' | 'oneOf';
+
 export type Options = {
     /**
      * Uses schemas as references, corresponding to their type references.
@@ -42,6 +44,11 @@ export type Options = {
      * @default true
      */
     nullableKeyword?: boolean;
+    /**
+     * Default schema type for union types..
+     * @default "anyOf"
+     */
+    defaultUnionModifier?: UnionModifier;
     /**
      * Default content type for all the operations. Can be overwritten case by case (See the annotations section.).
      * @default "* /*"


### PR DESCRIPTION
Right now, union types are created under the `anyOf` keys.

Using a generated schema with [Scalar](https://github.com/scalar/scalar) doesnt work properly as Scalar only handles `oneOf` schemas and ignores `anyOf` schemas. I have opened a PR with scalar to fix that issue'

However in the meanwhile, it would be a good option to have to allow users choose between the union types