### PR TITLE
refactor: migrate to ESM/CJS dual-package and clean up deprecated APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master, next]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20, 22, 24, 26]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Typescript OpenApiSpec contributors
+Copyright (c) 2026 Typescript OpenApiSpec contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![NPM version](https://img.shields.io/npm/v/ts-oas.svg)](https://www.npmjs.com/package/ts-oas)
 ![GitHub License](https://img.shields.io/github/license/ts-oas/ts-oas)
 ![NPM Unpacked Size](https://img.shields.io/npm/unpacked-size/ts-oas)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ts-oas/ts-oas)
 
-Automatically generate OpenAPI (formerly Swagger) specifications from opinionated Typescript types. Supports OpenAPI **v3.1** and **v3.0**. Requires interfaces/types in a specific format.
+Automatically generate OpenAPI (formerly Swagger) specifications from _opinionated_ Typescript types. Supports OpenAPI **v3.1** and **v3.0**. Requires interfaces/types in a specific format.
 
 ## Benefits
 
@@ -395,12 +396,6 @@ Ignores errors in Typescript files. May introduce wrong schemas.
 > _default: false_
 
 Replaces every type name with a unique hash to avoid duplication issues.
-
-#### `tsNodeRegister`
-
-> _default: false_
-
-Uses `ts-node/register` as a runtime argument, enabling direct execution of TypeScript on Node.js without precompiling.
 
 #### `nullableKeyword`
 

--- a/bin/ts-oas
+++ b/bin/ts-oas
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../dist/cli.js');
+import '../dist/cli.js';

--- a/package.json
+++ b/package.json
@@ -1,17 +1,7 @@
 {
   "name": "ts-oas",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Automatically generate OpenAPI specifications from opinionated Typescript types.",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
-  "files": [
-    "dist/",
-    "bin/",
-    "package.json",
-    "README.md",
-    "LICENSE"
-  ],
-  "author": "Alireza Malek",
   "repository": "https://github.com/ts-oas/ts-oas",
   "license": "MIT",
   "keywords": [
@@ -22,30 +12,73 @@
     "jsonschema",
     "schema"
   ],
+  "author": "Alireza Malek",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist/",
+    "bin/",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./cli": {
+      "import": {
+        "types": "./dist/cli.d.ts",
+        "default": "./dist/cli.js"
+      },
+      "require": {
+        "types": "./dist/cli.d.cts",
+        "default": "./dist/cli.cjs"
+      }
+    }
+  },
   "bin": {
     "ts-oas": "./bin/ts-oas"
   },
   "dependencies": {
     "fast-glob": "^3.3.3",
     "openapi-types": "^12.1.3",
-    "typescript": "~5.8.3",
     "yargs": "^17.7.2"
+  },
+  "peerDependencies": {
+    "typescript": ">=4.7 <6"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.9",
+    "@types/node": "^18.19.0",
     "@types/yargs": "^17.0.33",
     "ajv": "^8.17.1",
     "chai": "^4.5.0",
     "eslint": "^8.26.0",
     "mocha": "^10.7.3",
     "prettier": "^2.7.1",
-    "ts-node": "^10.9.1"
+    "tsup": "^8.5.0",
+    "tsx": "^4.20.5",
+    "typescript": "~5.8.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsup",
     "dev": "tsc -w",
-    "test": "mocha -t 3000 --require ts-node/register test/**/*.test.ts"
+    "test": "tsx node_modules/mocha/bin/mocha -t 10000 test/**/*.test.ts"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,9 @@
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
-import * as yargs from "yargs";
-import TypescriptOAS, { createProgram } from ".";
+import yargs from "yargs/yargs";
+import { TsOAS, createProgram } from ".";
 
-const argv = yargs
+const argv = yargs(process.argv.slice(2))
     .scriptName("ts-oas")
     .usage(
         "Usage: \u001b[0;33m$0 <file-paths> <type-names> [options]\u001b[0m\n\n<file-paths> : Comma-separated list of relative .ts file paths which contain types.\n<type-names> : Comma-separated list of type names (Regex/exact name) to be considered in files."
@@ -12,7 +12,7 @@ const argv = yargs
     .alias("h", "help")
     .alias("v", "version")
     .epilogue(
-        "Generate OpenAPI specifications from Typescript types.\nFor a full documentation, visit the homepage.\n\nHomepage: https://github.com/ts-oas/ts-oas 'Copyright 2023'"
+        "Generate OpenAPI specifications from Typescript types.\nFor a full documentation, visit the homepage.\n\nHomepage: https://github.com/ts-oas/ts-oas"
     )
     .example("$0 ./interfaces/sample.ts myApi,mySecondApi", "")
     .demandCommand(2, "\u001b[0;31mBoth <file-paths> and <type-names> are required arguments.\u001b[0m")
@@ -55,7 +55,7 @@ const OpenApiArgs = {
 };
 
 const program = createProgram(programArgs.files, programArgs.tsCompilerOptions, resolve());
-const tsoas = new TypescriptOAS(program, OpenApiArgs.options);
+const tsoas = new TsOAS(program, OpenApiArgs.options);
 
 let result: Record<any, any>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,3 @@
-import { TsOAS } from "./lib/TypescriptOAS";
-
-export { TsOAS };
+export { TsOAS } from "./lib/TypescriptOAS";
 export { createProgram } from "./util";
 export * from "./types";
-
-/**
- * @deprecated Will be removed in the next major version. Use named import instead:
- *
- * `import { TsOAS } from 'ts-oas'`
- */
-const TypescriptOAS = TsOAS;
-export default TypescriptOAS;

--- a/src/lib/SchemaGenerator.ts
+++ b/src/lib/SchemaGenerator.ts
@@ -6,7 +6,7 @@ import { OAS } from "../types";
 import { AnnotationKeywords, MetaDefinitionFields, PrimitiveType, UnionModifier } from "../types/common";
 import { openApiKeywords, refKeywords, REGEX_FILE_NAME_OR_SPACE, REGEX_REQUIRE, validationKeywords } from "../constant";
 
-const vm = require("vm");
+import * as vm from "vm";
 
 type RequiredOptions = Required<Omit<Options, "schemaProcessor">> & Pick<Options, "schemaProcessor">;
 
@@ -83,9 +83,6 @@ export class SchemaGenerator {
             }
         }
 
-        if (settings.tsNodeRegister) {
-            require("ts-node/register");
-        }
 
         if (!settings.ignoreErrors) {
             const diagnostics = ts.getPreEmitDiagnostics(program);
@@ -268,7 +265,6 @@ export class SchemaGenerator {
             uniqueNames: false,
             defaultUnionModifier: "anyOf",
             defaultNumberType: "number",
-            tsNodeRegister: false,
             nullableKeyword: true,
             defaultContentType: "*/*",
             customOperationProperties: false,
@@ -585,7 +581,7 @@ export class SchemaGenerator {
                     } else if (propertyType.flags & ts.TypeFlags.TemplateLiteral) {
                         definition.type = "string";
                         // @ts-ignore
-                        const {texts, types} = propertyType;
+                        const { texts, types } = propertyType;
                         const pattern: string[] = [];
                         for (let i = 0; i < texts.length; i++) {
                             const text = texts[i].replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");

--- a/src/lib/TypescriptOAS.ts
+++ b/src/lib/TypescriptOAS.ts
@@ -177,12 +177,12 @@ export class TsOAS extends SchemaGenerator {
         return responses;
     }
 
-    private getSecurity(type: ts.Type): OpenAPIV3.SecurityRequirementObject[] | undefined {
+    private getSecurity(type: ts.Type): OpenAPIV3.SecurityRequirementObject[] | OpenAPIV3_1.SecurityRequirementObject[] | undefined {
         if (this.isEmptyObj(type)) return undefined;
         if (!this.isValidObject(type)) throw new Error("Expected a valid Object.");
         if (this.getTypeDefinition(type).type !== "array") throw new Error("Expected to be an array");
 
-        const security: OpenAPIV3.SecurityRequirementObject[] = [];
+        const security: OpenAPIV3.SecurityRequirementObject[] | OpenAPIV3_1.SecurityRequirementObject[] = [];
         const typeDef = this.getTypeDefinition(type);
 
         if (typeDef?.items === undefined) return [];

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -35,11 +35,6 @@ export type Options = {
      */
     uniqueNames?: boolean;
     /**
-     * Uses `ts-node/register` as a runtime argument. It enables you to directly execute TypeScript on Node.js without precompiling.
-     * @default false
-     */
-    tsNodeRegister?: boolean;
-    /**
      * Provides `nullable: true` for nullable fields, otherwise set `type: "null"`.
      * @default true
      */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,4 @@
-export {
-    OpenApiSpecData,
-    OperationObject,
-    ParameterObject,
-    PathsObject,
-    RequestBodyObject,
-    ResponsesObject,
-    Version,
-    OpenApiSpec,
-    OAS,
-} from "./spec";
+export type { OAS } from "./spec";
 export * from "./enums/HttpStatusCode.enum";
 export * from "./enums/HTTPMethod.enum";
-export { Api, ApiMapper, Options } from "./common";
+export type { Api, ApiMapper, Options } from "./common";

--- a/src/types/spec.ts
+++ b/src/types/spec.ts
@@ -1,92 +1,6 @@
 import { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { HTTPMethod } from "./enums/HTTPMethod.enum";
 
-/**
- * @deprecated Use `OAS.Responses` instead. Will be removed in the next major version.
- */
-export type ResponsesObject = {
-    [key: string]: {
-        description?: string;
-        content: { [key: string]: { schema: OAS.Definition } };
-    };
-};
-
-/**
- * @deprecated Use `OAS.RequestBody` instead. Will be removed in the next major version.
- */
-export type RequestBodyObject = {
-    required?: boolean;
-    description?: string;
-    content: { [key: string]: { schema: OAS.Definition } };
-};
-
-/**
- * @deprecated Use `OAS.Parameter` instead. Will be removed in the next major version.
- */
-export type ParameterObject = {
-    name: string;
-    in: "path" | "query" | "header" | "cookie";
-    required: boolean;
-    description?: string;
-    schema: OAS.Definition;
-};
-
-/**
- * @deprecated Use `OAS.Operation` instead. Will be removed in the next major version.
- */
-export type OperationObject = {
-    summary?: string;
-    description?: string;
-    operationId?: string;
-    tags?: string[];
-    requestBody?: RequestBodyObject;
-    parameters?: ParameterObject[];
-    responses?: ResponsesObject;
-    security?: Record<string, string[]>[];
-};
-
-/**
- * @deprecated Use `OAS.Paths` instead. Will be removed in the next major version.
- */
-export type PathsObject = {
-    [path: string]: Partial<Record<Lowercase<HTTPMethod>, OperationObject>>;
-};
-
-/**
- * @deprecated Use `OAS.SpecVersion` instead. Will be removed in the next major version.
- */
-export type Version = "3.1.0" | "3.0.3";
-
-/**
- * @deprecated Use `OAS.SpecData` instead. Will be removed in the next major version.
- */
-export type OpenApiSpecData<T extends Version = "3.1.0"> = {
-    openapi?: T;
-    info?: T extends "3.1.0" ? OpenAPIV3_1.InfoObject : OpenAPIV3.InfoObject;
-    tags?: T extends "3.1.0" ? OpenAPIV3_1.TagObject[] : OpenAPIV3.TagObject[];
-    security?: T extends "3.1.0" ? OpenAPIV3_1.SecurityRequirementObject[] : OpenAPIV3.SecurityRequirementObject[];
-    servers?: T extends "3.1.0" ? OpenAPIV3_1.ServerObject[] : OpenAPIV3.ServerObject[];
-    externalDocs?: T extends "3.1.0" ? OpenAPIV3_1.ExternalDocumentationObject : OpenAPIV3.ExternalDocumentationObject;
-    components?: T extends "3.1.0"
-        ? Omit<OpenAPIV3_1.ComponentsObject, "schemas"> & {
-              schemas?: {
-                  [schemaName: string]: OpenAPIV3_1.ReferenceObject | OAS.Definition;
-              };
-          }
-        : Omit<OpenAPIV3.ComponentsObject, "schemas"> & {
-              schemas?: {
-                  [schemaName: string]: OpenAPIV3.ReferenceObject | OAS.Definition;
-              };
-          };
-};
-
-/**
- * @deprecated Use `OAS.Spec` instead. Will be removed in the next major version.
- */
-export type OpenApiSpec<T extends Version = "3.1.0"> = OpenApiSpecData<T> & {
-    paths: PathsObject;
-};
-
 type RedefinedFields = "type" | "items" | "allOf" | "oneOf" | "anyOf" | "not" | "additionalProperties" | "properties";
 
 export namespace OAS {
@@ -116,7 +30,7 @@ export namespace OAS {
         };
     };
 
-    export type RequestBody =  {
+    export type RequestBody = {
         required?: boolean;
         description?: string;
         content: { [key: string]: { schema: Definition } };
@@ -154,19 +68,19 @@ export namespace OAS {
         servers?: T extends "3.1.0" ? OpenAPIV3_1.ServerObject[] : OpenAPIV3.ServerObject[];
         externalDocs?: T extends "3.1.0" ? OpenAPIV3_1.ExternalDocumentationObject : OpenAPIV3.ExternalDocumentationObject;
         components?: T extends "3.1.0"
-            ? Omit<OpenAPIV3_1.ComponentsObject, "schemas"> & {
-                  schemas?: {
-                      [schemaName: string]: OpenAPIV3_1.ReferenceObject | Definition;
-                  };
-              }
-            : Omit<OpenAPIV3.ComponentsObject, "schemas"> & {
-                  schemas?: {
-                      [schemaName: string]: OpenAPIV3.ReferenceObject | Definition;
-                  };
-              };
+        ? Omit<OpenAPIV3_1.ComponentsObject, "schemas"> & {
+            schemas?: {
+                [schemaName: string]: OpenAPIV3_1.ReferenceObject | Definition;
+            };
+        }
+        : Omit<OpenAPIV3.ComponentsObject, "schemas"> & {
+            schemas?: {
+                [schemaName: string]: OpenAPIV3.ReferenceObject | Definition;
+            };
+        };
     };
 
-    export type Spec<T extends Version = "3.1.0"> = OpenApiSpecData<T> & {
-        paths: PathsObject;
+    export type Spec<T extends Version = "3.1.0"> = SpecData<T> & {
+        paths: Paths;
     };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as ts from "typescript";
-import * as fg from "fast-glob";
+import * as fastGlob from "fast-glob";
+const fg = (fastGlob as any).default || fastGlob;
 
 function hasGlobPattern(entry: string): boolean {
     return /[*?]/.test(entry);

--- a/test/openapi/openapi.test.ts
+++ b/test/openapi/openapi.test.ts
@@ -1,9 +1,14 @@
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { readFileSync, writeFileSync } from "fs";
 import { expect } from "chai";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { createProgram, TsOAS } from "../../src";
 import Ajv from "ajv";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 
 const openapiFile = JSON.parse(readFileSync(resolve(__dirname, `openapi.schema.json`), "utf8"));
 const openapiWithRefFile = JSON.parse(readFileSync(resolve(__dirname, `openapi-with-ref.schema.json`), "utf8"));
@@ -130,7 +135,7 @@ describe("openapi", () => {
 
         const pathKeys = Object.keys(spec.paths);
         const pathMethodKeys = Object.keys(spec.paths[pathKeys[0]]);
-        expect(spec.paths[pathKeys[0]][pathMethodKeys[0]]["responses"]["200"]["content"]).to.have.property(
+        expect((spec.paths[pathKeys[0]] as any)[pathMethodKeys[0]]["responses"]["200"]["content"]).to.have.property(
             "application/json"
         );
     });

--- a/test/schema-generator/schema-generator.test.ts
+++ b/test/schema-generator/schema-generator.test.ts
@@ -1,7 +1,12 @@
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { inspect } from "util";
 import { expect } from "chai";
 import { createProgram, TsOAS } from "../../src";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 import {
     schemaWithAdditionalProperties,
     schemaWithDefault,

--- a/test/util/util.test.ts
+++ b/test/util/util.test.ts
@@ -1,6 +1,10 @@
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { expect } from "chai";
 import { createProgram } from "../../src";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const fixturesDir = resolve(__dirname, "fixtures");
 const tsconfigPath = resolve(fixturesDir, "tsconfig.json");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ESNext",
     "moduleResolution": "node",
     "outDir": "dist",
     "isolatedModules": false,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    cli: 'src/cli.ts',
+  },
+  format: ['esm', 'cjs'],
+  target: 'node18',
+  outDir: 'dist',
+  sourcemap: false,
+  clean: true,
+  shims: true,
+  dts: true,
+  treeshake: true,
+  splitting: true,
+  platform: 'node',
+  external: [
+    'typescript',
+    'openapi-types',
+    'yargs',
+    '@apidevtools/swagger-parser',
+    'ajv'
+  ],
+  // Keep chunk names readable and stable
+  esbuildOptions(options) {
+    options.chunkNames = '[name]'
+  },
+})


### PR DESCRIPTION
- Build system migrated to tsup, outputting both ESM and CommonJS formats
- Removed deprecated default export (TypescriptOAS) and individual type exports in favor of named exports and the OAS namespace
- Removed the deprecated tsNodeRegister option from SchemaGenerator and Options
- Configured package exports mapping and enabled "type": "module" in package.json
- Adapted CLI, binary wrapper, and tests to be fully compatible with the new ESM environment
- Added a GitHub Actions CI workflow to test against Node.js versions 20 to 26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dual ESM/CommonJS package support with updated build output and CLI loading.
  * Added a new CI workflow that runs builds and tests across multiple Node.js versions.

* **Bug Fixes**
  * Improved compatibility with newer OpenAPI security requirement types.
  * Updated path handling in tests for better ESM support.

* **Documentation**
  * Refreshed the README badge section and removed an outdated option from the docs.

* **Chores**
  * Updated the package version, minimum Node.js requirement, and license year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->